### PR TITLE
Update to the latest openssl lib

### DIFF
--- a/Hands-on lab/HOL step-by step - Securing the IoT end to end.md
+++ b/Hands-on lab/HOL step-by step - Securing the IoT end to end.md
@@ -164,7 +164,7 @@ sudo apt-get upgrade
 
 sudo apt-get install -y git cmake build-essential curl libcurl4-openssl-dev libssl-dev uuid-dev
 
-sudo apt-get install libcurl3 libcurl-openssl1.0-dev
+sudo apt-get install libcurl4-openssl-dev
 sudo apt-get install auditd audispd-plugins
 
 ```


### PR DESCRIPTION
Previous apt-get libcurl-dev command raises an error on latest Ubuntu distro
(Unable to locate package libcurl-openssl1.0-dev)